### PR TITLE
Siirtymälinkkien korjaus osa -> osio.

### DIFF
--- a/src/locales/common/fi.json
+++ b/src/locales/common/fi.json
@@ -1,6 +1,6 @@
 {
     "endReached":"",
-    "continueToNext":"Seuraava osa:",
+    "continueToNext":"Seuraava osio:",
     "rememberToCheckPoints":"",
     "footer-src":"Materiaalin lähdekoodi",
     "footer-edit-page":"Muokkaa sivua",


### PR DESCRIPTION
Termejä osio ja luku käytetään sekaisin eri puolilla, tämä pitäisi yhdenmukaistaa kaikkialle.