### PR TITLE
11.4 virheellinen esimerkki

### DIFF
--- a/data/osa-11/4-lisaa-esimerkkeja.md
+++ b/data/osa-11/4-lisaa-esimerkkeja.md
@@ -457,7 +457,7 @@ niina
 
 komento: **6**
 koodari: **joona**
-työt: valmiina 2 ei valmiina 1, tunteja: tehty 55 tekemättä 1000
+työt: valmiina 1 ei valmiina 1, tunteja: tehty 55 tekemättä 1000
 
 </sample-output>
 


### PR DESCRIPTION
Esimerkissä lisätään neljä tilausta, joista kaksi on Joonan, yksi Niinan, ja yksi Erkin. Joonan tilausten summa ei siis voi olla kolme.